### PR TITLE
fix: Use seek-bzip for bzip inflation

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   },
   "dependencies": {
     "bn": "1.0.5",
-    "bzip-deflate": "^1.0.0",
+    "seek-bzip": "^2.0.0",
     "iced-error": "0.0.13",
     "iced-lock": "^2.0.1",
     "iced-runtime-3": "^3.0.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ importers:
       bn:
         specifier: 1.0.5
         version: 1.0.5
-      bzip-deflate:
-        specifier: ^1.0.0
-        version: 1.0.0
       iced-error:
         specifier: 0.0.13
         version: 0.0.13
@@ -38,6 +35,9 @@ importers:
       purepack:
         specifier: ^1.0.6
         version: 1.0.6
+      seek-bzip:
+        specifier: ^2.0.0
+        version: 2.0.0
       triplesec:
         specifier: ^4.0.3
         version: 4.0.3
@@ -250,9 +250,6 @@ packages:
   buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
 
-  bzip-deflate@1.0.0:
-    resolution: {integrity: sha512-9RMnpiJqMYMJcLdr4pxwowZ8Zh3P+tVswE/bnX6tZ14UGKNcdV5WVK2P+lGp2As+RCjl+i3SFJ117HyCaaHNDA==}
-
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
     engines: {node: '>= 0.4'}
@@ -321,6 +318,10 @@ packages:
   colors@1.4.0:
     resolution: {integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==}
     engines: {node: '>=0.1.90'}
+
+  commander@6.2.1:
+    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
+    engines: {node: '>= 6'}
 
   compare-func@2.0.0:
     resolution: {integrity: sha512-zHig5N+tPWARooBnb0Zx1MFcdfpyJrfTJ3Y5L+IFvUm8rM74hHz66z0gw0x4tijh5CorKkKUCnW82R2vmpeCRA==}
@@ -1183,6 +1184,10 @@ packages:
     resolution: {integrity: sha512-x/+Cz4YrimQxQccJf5mKEbIa1NzeCRNI5Ecl/ekmlYaampdNLPalVyIcCZNNH3MvmqBugV5TMYZXv0ljslUlaw==}
     engines: {node: '>= 0.4'}
 
+  seek-bzip@2.0.0:
+    resolution: {integrity: sha512-SMguiTnYrhpLdk3PwfzHeotrcwi8bNV4iemL9tx9poR/yeaMYwB9VzR1w7b57DuWpuqR8n6oZboi0hj3AxZxQg==}
+    hasBin: true
+
   semantic-release@24.2.8:
     resolution: {integrity: sha512-uvoLiKEB/AvvA3SCPE78cd90nVJXn220kkEA6sNGzDpas4s7pe4OgYWvhfR0lvWBdBH/T0RFCI6U+GvcT2CypQ==}
     engines: {node: '>=20.8.1'}
@@ -1691,8 +1696,6 @@ snapshots:
 
   buffer-from@1.1.2: {}
 
-  bzip-deflate@1.0.0: {}
-
   call-bind-apply-helpers@1.0.2:
     dependencies:
       es-errors: 1.3.0
@@ -1771,6 +1774,8 @@ snapshots:
   color-name@1.1.4: {}
 
   colors@1.4.0: {}
+
+  commander@6.2.1: {}
 
   compare-func@2.0.0:
     dependencies:
@@ -2563,6 +2568,10 @@ snapshots:
       call-bound: 1.0.4
       es-errors: 1.3.0
       is-regex: 1.2.1
+
+  seek-bzip@2.0.0:
+    dependencies:
+      commander: 6.2.1
 
   semantic-release@24.2.8:
     dependencies:

--- a/src/openpgp/packet/compressed.iced
+++ b/src/openpgp/packet/compressed.iced
@@ -4,7 +4,7 @@ C = require('../../const').openpgp
 asymmetric = require '../../asymmetric'
 zlib = require 'zlib'
 {uint_to_buffer} = require '../../util'
-bzipDeflate = require 'bzip-deflate'
+seekBzip = require 'seek-bzip'
 
 #=================================================================================
 
@@ -68,7 +68,7 @@ fix_zip_deflate = (buf, cb) ->
 bzip_inflate = (buf, cb) ->
   err = null
   try
-    ret = bzipDeflate buf
+    ret = seekBzip.decode buf
   catch e
     err = e
   cb err, ret


### PR DESCRIPTION
This PR updates kbpgp to use `seek-bzip` for bzip inflation instead of `bzip-deflate`. `seek-bzip` seems to be slightly better maintained (last updated 5 years ago as opposed to 10 years ago), is licenced properly, and has [code listed in GitHub](https://github.com/cscott/seek-bzip).

[`SheetJS/bz2`](https://github.com/SheetJS/bz2) was also considered but `seek-bzip` seems to be much more widely used and has been updated more recently.

- Fixes #133 